### PR TITLE
Added ability to stack timer buttons

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ export default class TimerPlugin extends Plugin {
     async onload(): Promise<void> {
         await this.loadSettings();
         this.statusBarItem = this.addStatusBarItem();
-        this.registerView(TIMER_VIEW_TYPE, (leaf) => new TimerView(leaf, this.settings.timerButtonsSettings, this.statusBarItem));
+        this.registerView(TIMER_VIEW_TYPE, (leaf) => new TimerView(leaf, this.settings, this.statusBarItem));
         this.addRibbonIcon('alarm-clock', 'Open timer', async () => await this.openView());
         this.addCommands();
         this.addSettingTab(new TimerSettingsTab(this.app, this));
@@ -75,7 +75,7 @@ export default class TimerPlugin extends Plugin {
         if (leaves.length == 0) return;
         const view = (leaves[0].view as TimerView);
         if (timer) await view.updateTimer(timer);
-        else await view.updateSettings(this.settings.timerButtonsSettings);
+        else await view.updateSettings(this.settings);
     }
 
     private addFavoriteTimer = async () => {

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,4 +1,4 @@
-import { App, Notice, PluginSettingTab, Setting } from 'obsidian';
+import { App, Notice, PluginSettingTab, Setting, ToggleComponent } from 'obsidian';
 import TimerPlugin from 'src/main';
 
 export class TimerButtonsSettings {
@@ -10,11 +10,13 @@ export class TimerButtonsSettings {
 export interface TimerSettings {
     timerButtonsSettings: TimerButtonsSettings;
     favoriteTimers: string[];
+    stackTimerButtons: boolean;
 }
 
 export const DEFAULT_SETTINGS: TimerSettings = {
     timerButtonsSettings: new TimerButtonsSettings('1s', '1m', '10m', '1h'),
-    favoriteTimers: []
+    favoriteTimers: [],
+    stackTimerButtons: false
 };
 
 export class TimerSettingsTab extends PluginSettingTab {
@@ -29,6 +31,7 @@ export class TimerSettingsTab extends PluginSettingTab {
     display(): void {
         this.containerEl.empty();
         this.timerButtonsSettings();
+        this.stackButtonSettings();
     }
 
     private timerButtonsSettings(): void {
@@ -74,5 +77,18 @@ export class TimerSettingsTab extends PluginSettingTab {
         const properties = ['first', 'second', 'third', 'fourth'];
         this.plugin.settings.timerButtonsSettings[properties[index]] = value;
         await this.plugin.saveSettings();
+    }
+
+    private stackButtonSettings(): void {
+        new Setting(this.containerEl)
+            .setName('Stack timer buttons')
+            .setDesc('If enabled, the timer increment buttons will be stacked on top of the timer decrement buttons. If disabled, the timer increment buttons will be placed to the right of the timer decrement buttons.')
+            .addToggle(toggle => toggle
+                .setValue(this.plugin.settings.stackTimerButtons)
+                .onChange(async value => {
+                    this.plugin.settings.stackTimerButtons = value;
+                    await this.plugin.saveSettings();
+                })
+            );
     }
 }

--- a/src/ui/timerButtonsUi.tsx
+++ b/src/ui/timerButtonsUi.tsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { TimerButtonsSettingsContext } from 'src/views/view';
+import { TimerButtonsSettingsContext, StackTimerButtonsContext } from 'src/views/view';
 
 interface ITimerButtonsUi {
     updateTimer: (update: string) => void;
@@ -8,7 +8,7 @@ interface ITimerButtonsUi {
 export default function TimerButtonsUi({ updateTimer }: ITimerButtonsUi) {
     const { first, second, third, fourth } = useContext(TimerButtonsSettingsContext);
     const settings = [first, second, third, fourth];
-    const stackTimerButtons = false; 
+    const stackTimerButtons = useContext(StackTimerButtonsContext);
 
     if (stackTimerButtons) {
         return (

--- a/src/ui/timerButtonsUi.tsx
+++ b/src/ui/timerButtonsUi.tsx
@@ -8,9 +8,19 @@ interface ITimerButtonsUi {
 export default function TimerButtonsUi({ updateTimer }: ITimerButtonsUi) {
     const { first, second, third, fourth } = useContext(TimerButtonsSettingsContext);
     const settings = [first, second, third, fourth];
+    const stackTimerButtons = false; 
 
-    return <div className='timerButtonsContainer'>
-        {settings.reverse().map(v => <button key={`-${v}`} onClick={() => updateTimer(`-${v}`)}>-{v}</button>)}
-        {settings.reverse().map(v => <button key={`+${v}`} onClick={() => updateTimer(`+${v}`)}>+{v}</button>)}
-    </div>;
+    if (stackTimerButtons) {
+        return (
+            <div className='timerButtonsContainer' style={{ display: 'flex', flexDirection: 'column'}}>
+                <div>{settings.reverse().map(v => <button key={`+${v}`} onClick={() => updateTimer(`+${v}`)} style={{ margin: '5px', width: '50px' }}>+{v}</button>)}</div>
+                <div>{settings.map(v => <button key={`-${v}`} onClick={() => updateTimer(`-${v}`)} style={{ margin: '5px', width: '50px' }}>-{v}</button>)}</div>
+            </div>
+        );
+    } else {
+        return <div className='timerButtonsContainer'>
+            {settings.reverse().map(v => <button key={`-${v}`} onClick={() => updateTimer(`-${v}`)}>-{v}</button>)}
+            {settings.reverse().map(v => <button key={`+${v}`} onClick={() => updateTimer(`+${v}`)}>+{v}</button>)}
+        </div>;
+    }
 }

--- a/src/ui/timerButtonsUi.tsx
+++ b/src/ui/timerButtonsUi.tsx
@@ -1,14 +1,15 @@
 import { useContext } from 'react';
-import { TimerButtonsSettingsContext, StackTimerButtonsContext } from 'src/views/view';
+import { TimerSettingsContext } from 'src/views/view';
 
 interface ITimerButtonsUi {
     updateTimer: (update: string) => void;
 }
 
 export default function TimerButtonsUi({ updateTimer }: ITimerButtonsUi) {
-    const { first, second, third, fourth } = useContext(TimerButtonsSettingsContext);
+    const timerSettings = useContext(TimerSettingsContext);
+    const { first, second, third, fourth } = timerSettings.timerButtonsSettings;
     const settings = [first, second, third, fourth];
-    const stackTimerButtons = useContext(StackTimerButtonsContext);
+    const stackTimerButtons = timerSettings.stackTimerButtons;
 
     if (stackTimerButtons) {
         return (

--- a/src/views/view.tsx
+++ b/src/views/view.tsx
@@ -1,26 +1,29 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import * as React from 'react';
 import { Root, createRoot } from 'react-dom/client';
-import { DEFAULT_SETTINGS, TimerButtonsSettings } from 'src/settings/settings';
+import { DEFAULT_SETTINGS, TimerSettings, TimerButtonsSettings } from 'src/settings/settings';
 import Timer from 'src/timer/timer';
 import TimerUi from 'src/ui/timerUi';
 
 export const TIMER_VIEW_TYPE = 'Timer';
 
 export const TimerButtonsSettingsContext= React.createContext(DEFAULT_SETTINGS.timerButtonsSettings);
+export const StackTimerButtonsContext = React.createContext(DEFAULT_SETTINGS.stackTimerButtons);
 
 export default class TimerView extends ItemView {
     private container: HTMLDivElement;
     private root: Root;
     private timerButtonsSettings: TimerButtonsSettings;
+    private stackTimerButtons: boolean;
     private timer: Timer;
     private statusBarItem: HTMLElement;
     icon = 'alarm-clock';
 
-    constructor(leaf: WorkspaceLeaf, timerButtonsSettings: TimerButtonsSettings, statusBarItem: HTMLElement) {
+    constructor(leaf: WorkspaceLeaf, timerSettings: TimerSettings, statusBarItem: HTMLElement) {
         super(leaf);
-        this.timerButtonsSettings = timerButtonsSettings;
+        this.timerButtonsSettings = timerSettings.timerButtonsSettings;
         this.statusBarItem = statusBarItem;
+        this.stackTimerButtons = timerSettings.stackTimerButtons;
     }
 
     async updateTimer(timer: Timer): Promise<void> {
@@ -34,8 +37,9 @@ export default class TimerView extends ItemView {
         this.renderRoot(updatedSettings);
     }
 
-    async updateSettings(timerButtonsSettings: TimerButtonsSettings): Promise<void> {
-        this.timerButtonsSettings = timerButtonsSettings;
+    async updateSettings(timerSettings: TimerSettings): Promise<void> {
+        this.timerButtonsSettings = timerSettings.timerButtonsSettings;
+        this.stackTimerButtons = timerSettings.stackTimerButtons;
         await this.reload(true);
     }
 
@@ -43,7 +47,9 @@ export default class TimerView extends ItemView {
         this.root.render(
             <React.StrictMode>
                 <TimerButtonsSettingsContext.Provider value={this.timerButtonsSettings}>
-                    <TimerUi timerInput={this.timer} updatedSettings={updatedSettings} statusBarItem={this.statusBarItem}/>
+                    <StackTimerButtonsContext.Provider value={this.stackTimerButtons}>
+                        <TimerUi timerInput={this.timer} updatedSettings={updatedSettings} statusBarItem={this.statusBarItem} />
+                    </StackTimerButtonsContext.Provider>
                 </TimerButtonsSettingsContext.Provider>
             </React.StrictMode>
         );

--- a/src/views/view.tsx
+++ b/src/views/view.tsx
@@ -1,29 +1,26 @@
 import { ItemView, WorkspaceLeaf } from 'obsidian';
 import * as React from 'react';
 import { Root, createRoot } from 'react-dom/client';
-import { DEFAULT_SETTINGS, TimerSettings, TimerButtonsSettings } from 'src/settings/settings';
+import { DEFAULT_SETTINGS, TimerSettings } from 'src/settings/settings';
 import Timer from 'src/timer/timer';
 import TimerUi from 'src/ui/timerUi';
 
 export const TIMER_VIEW_TYPE = 'Timer';
 
-export const TimerButtonsSettingsContext= React.createContext(DEFAULT_SETTINGS.timerButtonsSettings);
-export const StackTimerButtonsContext = React.createContext(DEFAULT_SETTINGS.stackTimerButtons);
+export const TimerSettingsContext = React.createContext(DEFAULT_SETTINGS);
 
 export default class TimerView extends ItemView {
     private container: HTMLDivElement;
     private root: Root;
-    private timerButtonsSettings: TimerButtonsSettings;
-    private stackTimerButtons: boolean;
+    private timerSettings: TimerSettings;
     private timer: Timer;
     private statusBarItem: HTMLElement;
     icon = 'alarm-clock';
 
     constructor(leaf: WorkspaceLeaf, timerSettings: TimerSettings, statusBarItem: HTMLElement) {
         super(leaf);
-        this.timerButtonsSettings = timerSettings.timerButtonsSettings;
+        this.timerSettings = timerSettings
         this.statusBarItem = statusBarItem;
-        this.stackTimerButtons = timerSettings.stackTimerButtons;
     }
 
     async updateTimer(timer: Timer): Promise<void> {
@@ -38,19 +35,19 @@ export default class TimerView extends ItemView {
     }
 
     async updateSettings(timerSettings: TimerSettings): Promise<void> {
-        this.timerButtonsSettings = timerSettings.timerButtonsSettings;
-        this.stackTimerButtons = timerSettings.stackTimerButtons;
+        this.timerSettings = timerSettings
         await this.reload(true);
     }
 
     private renderRoot(updatedSettings: boolean): void {
         this.root.render(
             <React.StrictMode>
-                <TimerButtonsSettingsContext.Provider value={this.timerButtonsSettings}>
-                    <StackTimerButtonsContext.Provider value={this.stackTimerButtons}>
-                        <TimerUi timerInput={this.timer} updatedSettings={updatedSettings} statusBarItem={this.statusBarItem} />
-                    </StackTimerButtonsContext.Provider>
-                </TimerButtonsSettingsContext.Provider>
+                <TimerSettingsContext.Provider value={this.timerSettings}>
+                    <TimerUi
+                        timerInput={this.timer}
+                        updatedSettings={updatedSettings}
+                        statusBarItem={this.statusBarItem} />
+                </TimerSettingsContext.Provider>
             </React.StrictMode>
         );
     }


### PR DESCRIPTION
the current implementation wasn't too responsive with all the buttons laid out in a row. i added an option in settings so that users can choose to stack their buttons. when buttons are stacked, they are more responsive and friendly to smaller screens

https://github.com/Raboro/obsidian-timer-plugin/assets/4106884/0c71bf47-6455-4cb1-ad66-c5fefeb90a00